### PR TITLE
fix: add 'use client' directive to track page

### DIFF
--- a/econutrient/src/app/track/page.tsx
+++ b/econutrient/src/app/track/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState } from "react";
 
 export default function TrackPage() {


### PR DESCRIPTION
This PR fixes the React hooks error in the track page by adding the required 'use client' directive for Next.js App Router.